### PR TITLE
Fix bug in kafka-consumer.js when setting groupid

### DIFF
--- a/js/kafka-consumer.js
+++ b/js/kafka-consumer.js
@@ -20,7 +20,7 @@ module.exports = function(RED) {
 
             var topic = config.topic;
     
-            options.groupId = 'nodered_kafka_client_' + config.groupid || + e1();
+            options.groupId = 'nodered_kafka_client_' + !config.groupid || config.groupid === '' ? e1() : config.groupid;
             options.fromOffset = config.fromOffset;
             options.outOfRangeOffset = config.outOfRangeOffset;
             options.fetchMinBytes = config.minbytes || 1;


### PR DESCRIPTION
The logic to set `options.groupId` relied on `config.groupid` being `null` or `undefined`
but in fact `config.groupid` can be an empty `string` so when using several consumers
all of them would be in the same consumer group `'nodered_kafka_client_'`

Just added some logic to account for the empty string.