### PR TITLE
Adding encoding option to consumer

### DIFF
--- a/js/kafka-consumer.html
+++ b/js/kafka-consumer.html
@@ -50,6 +50,14 @@
          </select>
     </div>
 
+    <div class="form-row">
+        <label for="node-input-encoding"><i class="fa fa-tag"></i> Message encoding</label>
+         <select id="node-input-encoding">
+         	<option value="utf8">UTF-8</option>
+         	<option value="buffer">buffer</option>
+         </select>
+    </div>
+
 </script>
 
 <script type="text/javascript">
@@ -61,7 +69,8 @@
             outOfRangeOffset: {value:"earliest"},
             fromOffset: {value:"latest"},
             topic: {required:true},
-            groupid: {required:false}
+            groupid: {required:false},
+            encoding: {value: "utf8"}
         },
         inputs:0,
         outputs:1,

--- a/js/kafka-consumer.js
+++ b/js/kafka-consumer.js
@@ -25,6 +25,7 @@ module.exports = function(RED) {
             options.outOfRangeOffset = config.outOfRangeOffset;
             options.fetchMinBytes = config.minbytes || 1;
             options.fetchMaxBytes = config.maxbytes || 1048576;
+            options.encoding = config.encoding || 'utf8';
 
             node.lastMessageTime = null;
 


### PR DESCRIPTION
Not all messages over kafka can be easily decoded as utf8, for example Protobuffers.

This PR adds an Encoding option to the Consumer Node that allows you to select between the `utf-8` and `buffer` options that the underlying `kafka-node` module provides.

Signed-off-by: James Sutton <1068763+jpwsutton@users.noreply.github.com>